### PR TITLE
add a `__hash__` method to Vnlv dataclass for Python3.11 compatibility

### DIFF
--- a/pynqmetadata/models/vlnv.py
+++ b/pynqmetadata/models/vlnv.py
@@ -40,3 +40,7 @@ class Vlnv:
     def str(self) -> str:
         """Returns a stringified version of the VLNV"""
         return f"{self.vendor}:{self.library}:{self.name}:{self.version[0]}.{self.version[1]}"
+                
+    def __hash__(self):
+        """Returns a hash of the object."""
+        return hash(self.str)


### PR DESCRIPTION
A breaking change in Python3.11 is to "Change field default mutability check, allowing only defaults which are hashable instead of any object which is not an instance of dict, list or set. (Contributed by Eric V. Smith in bpo-44674.)", see https://docs.python.org/3/whatsnew/3.11.html#dataclasses.

This makes it so Vnlv cannot be used as a default argument for DFXCore.vlnv and `import pynqmetadata` fails when using Python3.11, as does `import pynq`

The ways to fix are either to:
* add a __hash__ method to Vlnv
* use a a field with a default_factory for DFXCore.vlnv (e.g. vlnv: Vlnv = field(default_factory=lambda: Vlnv(vendor="xilinx.com", library="ip", name="dfx", version=(1, 0)))

in order to avoid the error...
```>>> import pynqmetadata
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/user/PYNQ-Metadata/pynqmetadata/__init__.py", line 5, in <module>
    from .models.bit_field import BitField
  File "/home/user/PYNQ-Metadata/pynqmetadata/models/__init__.py", line 9, in <module>
    from .dfx_core import DFXCore
  File "/home/user/PYNQ-Metadata/pynqmetadata/models/dfx_core.py", line 10, in <module>
    @dataclass(repr=False)
     ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dataclasses.py", line 1210, in wrap
    return _process_class(cls, init, repr, eq, order, unsafe_hash,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dataclasses.py", line 958, in _process_class
    cls_fields.append(_get_field(cls, name, type, kw_only))
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dataclasses.py", line 815, in _get_field
    raise ValueError(f'mutable default {type(f.default)} for field '
ValueError: mutable default <class 'pynqmetadata.models.vlnv.Vlnv'> for field vlnv is not allowed: use default_factory
>>> 
```


After either one of these changes, `import pynqmetadata` works in Python3.11.