### PR TITLE
include ipython requirement of pynqmetadata.frontend

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,8 @@ extend_pynq_metadata_package([
 # Required packages
 required = [
         "jsonschema>=3.2.0",
-        "pydantic"
+        "pydantic",
+        "ipython",
 ]
 
 


### PR DESCRIPTION
in a fresh virtual environment, after `pip install pynq`,  and `pip install pynqmetadata`, `import pynq` fails due to the missing `ipython` dependency. 

I am using 
```
pynq==3.0.1
pynqmetadata==0.1.5
```

and the traceback is 
```
    import pynq
/usr/local/lib/python3.11/site-packages/pynq/__init__.py:11: in <module>
    from .overlay import DefaultHierarchy, DefaultIP, Overlay, UnsupportedConfiguration
/usr/local/lib/python3.11/site-packages/pynq/overlay.py:13: in <module>
    from pynqmetadata.frontends import Metadata
/usr/local/lib/python3.11/site-packages/pynqmetadata/frontends/__init__.py:7: in <module>
    from . import visualisations
/usr/local/lib/python3.11/site-packages/pynqmetadata/frontends/visualisations/__init__.py:4: in <module>
    from .metadata_vis import MetadataVis
/usr/local/lib/python3.11/site-packages/pynqmetadata/frontends/visualisations/metadata_vis.py:4: in <module>
    from IPython.display import display, Javascript, HTML
E   ModuleNotFoundError: No module named 'IPython'
```

This error occurs on Python3.10 and Python3.11. It is easily fixed by `pip install ipython` but is an inconvenience when installing the package.