### PR TITLE
add pydantic v2 support

### DIFF
--- a/pynqmetadata/models/metadata_extension.py
+++ b/pynqmetadata/models/metadata_extension.py
@@ -15,5 +15,7 @@ class MetadataExtension(pydantic.BaseModel):
     of that space
     """
 
-    class Config:
-        underscore_attrs_are_private = True
+    # In Pydantic v2+, underscore attrs are private by default
+    if int(pydantic.__version__.split('.')[0]) < 2:
+        class Config:
+            underscore_attrs_are_private = True


### PR DESCRIPTION
The behaviour of Pydantic has changed in version 2+. `underscore_attrs_are_private` is now `True` by default. Setting it causes a `UserWarning` when importing `pynqmetadata`. Adding if/else with version check to support both versions.

Fixes #26 