### PR TITLE
Fix `ParameterNotFound` on every Versal overlay load

### DIFF
--- a/pynqmetadata/models/versal_proc_sys_core.py
+++ b/pynqmetadata/models/versal_proc_sys_core.py
@@ -12,17 +12,17 @@ from .proc_sys_core import ProcSysCore
 class VersalProcSysCore(ProcSysCore):
     """A specialised model for the Versal CIPS processing system.
 
-    Versal PL clocks are frequency-based (set in PS_PMC_CONFIG) rather than
-    divisor-based like Zynq/Ultrascale.
+    Versal PL clocks are frequency-based (set in PS_PMC_CONFIG_INTERNAL)
+    rather than divisor-based like Zynq/Ultrascale.
     """
 
     type: str = "core-versal"
     ps_name: str = "versal_cips"
 
     def _ps_pmc_config(self) -> str:
-        if "PS_PMC_CONFIG" in self.parameters:
-            return self.parameters["PS_PMC_CONFIG"].value or ""
-        raise ParameterNotFound(f"PS_PMC_CONFIG not found for {self.ref}")
+        if "PS_PMC_CONFIG_INTERNAL" in self.parameters:
+            return self.parameters["PS_PMC_CONFIG_INTERNAL"].value or ""
+        raise ParameterNotFound(f"PS_PMC_CONFIG_INTERNAL not found for {self.ref}")
 
     def find_clock_frequency(self, clk_id: int) -> float:
         """Return the PL clock reference frequency in MHz."""
@@ -33,3 +33,11 @@ class VersalProcSysCore(ProcSysCore):
 
     def find_clock_enable(self, clk_id: int) -> bool:
         return self.find_clock_frequency(clk_id) > 0
+
+    def find_clock_divisor(self, clk_id: int, div_id: int) -> int:
+        """Return the PL clock divisor. For Versal only DIVISOR0 exists."""
+        m = re.search(
+            rf"PMC_CRP_PL{clk_id}_REF_CTRL_DIVISOR{div_id}\s+([0-9]+)",
+            self._ps_pmc_config(),
+        )
+        return int(m.group(1)) if m else 1


### PR DESCRIPTION
Constructing an `Overlay` on any Versal device fails:

```
ParameterNotFound: Unable to find a clock divison
PSU__CRL_APB__PL0_REF_CTRL__DIVISOR0 for ps base:versal_cips_0[block]
```

Two causes, both in `versal_proc_sys_core.py`:

1. **No `find_clock_divisor` override.** The `VersalProcSysCore` class overrides frequency and enable but not divisor, so it inherits the Ultrascale version from `ProcSysCore`. `ClockDictView` requests divisors for clocks 0–3 while building `clock_dict`, before any user code  runs. Hence, versal overlay load failed.

2. **Wrong config parameter.** Versal PL clock data doesn't always seem to live in `PS_PMC_CONFIG`  (the wizard input). One test I carried out showed it lives in there when clocks don't equal 333MHz, however more testing required. This information can always be found in  `PS_PMC_CONFIG_INTERNAL` (Vivado's elaborated output). Using `PS_PMC_CONFIG`, when parameters weren't present, the existing frequency/enable had been silently returning `0.0` / `False`.