### PR TITLE
make the package importable on Python 3.12 and declare the real version floor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.hwh
+*.egg-info/
+build/
+dist/

--- a/pynqmetadata/frontends/metadata.py
+++ b/pynqmetadata/frontends/metadata.py
@@ -3,7 +3,6 @@
 
 import json
 import os
-from distutils.command.install_headers import install_headers
 from typing import Optional
 
 from pydantic import Field

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ setup(  name='pynqmetadata',
         author_email='pynq_support@xilinx.com',
         packages=find_packages(),
         install_requires=required,
-        python_requires='>=3.8',
+        python_requires='>=3.10',
         package_data = {
             'pynqmetadata': pynq_metadata_files,
             },


### PR DESCRIPTION
metadata.py imported distutils.command.install_headers and never used it. distutils was removed in 3.12, so importing any frontend raised ModuleNotFoundError there.

ipython requires 3.10, while pydantic and jsonschema require 3.9. Raised to 3.10 to match.